### PR TITLE
Add error message checking

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,72 @@
+import * as vscode from "vscode";
+import { RealmFS } from "./fileSystemProvider";
+type ApiError = {
+  message: string;
+};
+
+async function getErrorMessagesForFile(
+  fileUri: vscode.Uri,
+  realmFs: RealmFS
+): Promise<string | undefined> {
+  const file = await realmFs.fetchRawTextFile(fileUri);
+  if (file.status == 200) {
+    return undefined;
+  }
+  return file.body;
+}
+
+function extractErrorsFromMessage(message: string): vscode.Diagnostic[] {
+  const diagnostics: vscode.Diagnostic[] = [];
+  //Check the first line looks like a file path, then a colon, and finishes with (number:number)
+  const lines = message.split("\n");
+  const firstLine = lines[0];
+  const filePathMatch = firstLine.match(/^(.+?):(.+?)\((\d+):(\d+)\)$/);
+  console.log("filePathMatch", filePathMatch);
+  console.log("firstLine", firstLine);
+  let range: vscode.Range;
+  if (filePathMatch) {
+    console.log("filePathMatch", filePathMatch);
+    const lineNumber = parseInt(filePathMatch[3]) - 1;
+    const columnNumber = parseInt(filePathMatch[4]) - 1;
+    range = new vscode.Range(
+      lineNumber,
+      columnNumber,
+      lineNumber,
+      columnNumber
+    );
+  } else {
+    range = new vscode.Range(0, 0, 0, 0);
+  }
+
+  const diagnostic = new vscode.Diagnostic(
+    range,
+    message,
+    vscode.DiagnosticSeverity.Error // Or Warning, Information, etc.
+  );
+
+  diagnostic.source = "boxelrealm";
+
+  diagnostics.push(diagnostic);
+
+  return diagnostics;
+}
+
+export function updateDiagnostics(
+  document: vscode.TextDocument,
+  diagnosticCollection: vscode.DiagnosticCollection,
+  realmFs: RealmFS
+): void {
+  getErrorMessagesForFile(document.uri, realmFs)
+    .then((apiErrors) => {
+      if (apiErrors) {
+        const diagnostics = extractErrorsFromMessage(apiErrors);
+        diagnosticCollection.set(document.uri, diagnostics);
+      } else {
+        diagnosticCollection.delete(document.uri);
+      }
+    })
+    .catch((error) => {
+      console.error("Failed to fetch errors:", error);
+      diagnosticCollection.delete(document.uri); // Clear diagnostics on error
+    });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,13 @@
 import * as vscode from "vscode";
 import { RealmFS } from "./fileSystemProvider";
 import { SynapseAuthProvider } from "./synapse-auth-provider";
+import { updateDiagnostics } from "./diagnostics";
 
 export async function activate(context: vscode.ExtensionContext) {
+  const diagnosticCollection =
+    vscode.languages.createDiagnosticCollection("boxelrealm");
+  context.subscriptions.push(diagnosticCollection);
+
   const authProvider = new SynapseAuthProvider(context);
   context.subscriptions.push(
     vscode.authentication.registerAuthenticationProvider(
@@ -31,6 +36,29 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.registerFileSystemProvider("boxelrealm+https", realmFs, {
       isCaseSensitive: true,
+    })
+  );
+
+  // Update diagnostics when the active editor changes
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor) {
+        updateDiagnostics(editor.document, diagnosticCollection, realmFs);
+      }
+    })
+  );
+
+  // Update diagnostics when a document is saved
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((document) => {
+      updateDiagnostics(document, diagnosticCollection, realmFs);
+    })
+  );
+
+  // Clear diagnostics when a document is closed
+  context.subscriptions.push(
+    vscode.workspace.onDidCloseTextDocument((document) => {
+      diagnosticCollection.delete(document.uri);
     })
   );
 

--- a/src/fileSystemProvider.ts
+++ b/src/fileSystemProvider.ts
@@ -352,6 +352,23 @@ export class RealmFS implements vscode.FileSystemProvider {
     }
   }
 
+  async fetchRawTextFile(
+    uri: vscode.Uri
+  ): Promise<{ status: number; body: string }> {
+    console.log("Fetching raw file:", uri);
+    let apiUrl = getUrl(uri);
+    console.log("API URL:", apiUrl);
+    const headers = {
+      Authorization: `${await this.getJWT(apiUrl)}`,
+    };
+
+    const response = await fetch(apiUrl, { headers });
+    return {
+      status: response.status,
+      body: await response.text(),
+    };
+  }
+
   private async _fetchFileEntry(uri: vscode.Uri): Promise<File> {
     console.log("Fetching file entry:", uri);
     let apiUrl = getUrl(uri);


### PR DESCRIPTION
On the save of a document, fetch it without any accept headers and see if we get a non 200 response, if so try and parse the error message to get the error location. Failing that, put it at the top of the document so it's at least present. The other option is to mark the entire file as erroneous, but that may be too over the top.

We can get smarter with this, but this shows the main places to hook into to show errors.